### PR TITLE
Add support for M82 and M83

### DIFF
--- a/js/gcodeProcessor.js
+++ b/js/gcodeProcessor.js
@@ -951,9 +951,11 @@ function GcodeProcessor() {
                 this.calculateBasicMovementInfo(gcode);
                 break;
             case "G90":
+            case "M82":
                 this.absoluteExtrusion = true;
                 break;
             case "G91":
+            case "M83":
                 this.absoluteExtrusion = false;
                 break;
             case "G92":


### PR DESCRIPTION
M82 and M83 are commands to set absolute/relative positioning in Marlin-based printers.

http://marlinfw.org/docs/gcode/M082.html